### PR TITLE
gettransaction for correct network

### DIFF
--- a/bitcoinlib/services/bitcoind.py
+++ b/bitcoinlib/services/bitcoind.py
@@ -145,7 +145,7 @@ class BitcoindClient(BaseClient):
 
     def gettransaction(self, txid):
         tx = self.proxy.getrawtransaction(txid, 1)
-        t = Transaction.import_raw(tx['hex'])
+        t = Transaction.import_raw(tx['hex'], network=self.network)
         t.confirmations = tx['confirmations']
         if t.confirmations:
             t.status = 'confirmed'


### PR DESCRIPTION
Add paramter to import transaction for the correct network. This fixes a bug where the addresses are not correctly parsed when using the testnet.